### PR TITLE
Add .mjs for ESM modules in node

### DIFF
--- a/after/ftplugin/javascript_apathy.vim
+++ b/after/ftplugin/javascript_apathy.vim
@@ -6,7 +6,7 @@ endif
 call map(b:node_modules, 'fnamemodify(v:val, ":p")')
 
 call apathy#Prepend('path', b:node_modules, apathy#EnvSplit($NODE_PATH))
-call apathy#Prepend('suffixesadd', '.coffee,.ts,.tsx,.js,.jsx,.json,.node')
+call apathy#Prepend('suffixesadd', '.coffee,.ts,.tsx,.js,.mjs,.jsx,.json,.node')
 call apathy#Append('suffixesadd', '/package.json')
 setlocal include=\\%(\\<require\\s*(\\s*\\\|\\<import\\>[^;\"']*\\)[\"']\\zs[^\"']*
 setlocal includeexpr=JavascriptNodeFind(v:fname,@%)


### PR DESCRIPTION
Node uses `.mjs` to distinguish between commonjs and ES6 modules. This makes it possible to support both `require` and `import`/`export` natively in node.

See https://nodejs.org/api/esm.html for more info