### PR TITLE
Add clang support for c/c++

### DIFF
--- a/after/ftplugin/c_apathy.vim
+++ b/after/ftplugin/c_apathy.vim
@@ -1,7 +1,13 @@
+if has('osx')
+  let s:exe = 'clang'
+else
+  let s:exe = 'cpp'
+endif
+
 function! s:CPreProcIncludes(cmd) abort
   let paths = []
   let active = 0
-  for line in executable('cpp') ? split(system(a:cmd), "\n") : []
+  for line in executable(s:exe) ? split(system(a:cmd), "\n") : []
     if line =~# '^#include '
       let active = 1
     elseif line =~# '^\S'
@@ -15,16 +21,17 @@ endfunction
 
 if &filetype ==# 'cpp' 
   if !exists('g:cpp_path')
-    let g:cpp_path = ['.'] + s:CPreProcIncludes('cpp -v -x c++')
+    let g:cpp_path = ['.'] + s:CPreProcIncludes(s:exe . ' -v -x c++ /dev/null')
   endif
   call apathy#Prepend('path', g:cpp_path)
 else
   if !exists('g:c_path')
-    let g:c_path = ['.'] + s:CPreProcIncludes('cpp -v -x c')
+    let g:c_path = ['.'] + s:CPreProcIncludes(s:exe . ' -v -x c /dev/null')
   endif
   call apathy#Prepend('path', g:c_path)
 endif
 
+unlet! s:exe
 setlocal include&
 setlocal includeexpr&
 setlocal define&

--- a/after/ftplugin/c_apathy.vim
+++ b/after/ftplugin/c_apathy.vim
@@ -1,13 +1,7 @@
-if has('osx')
-  let s:exe = 'clang'
-else
-  let s:exe = 'cpp'
-endif
-
-function! s:CPreProcIncludes(cmd) abort
+function! s:CPreProcIncludes(exe, opts) abort
   let paths = []
   let active = 0
-  for line in executable(s:exe) ? split(system(a:cmd), "\n") : []
+  for line in executable(a:exe) ? split(system(a:exe . ' ' . a:opts), "\n") : []
     if line =~# '^#include '
       let active = 1
     elseif line =~# '^\S'
@@ -21,17 +15,18 @@ endfunction
 
 if &filetype ==# 'cpp' 
   if !exists('g:cpp_path')
-    let g:cpp_path = ['.'] + s:CPreProcIncludes(s:exe . ' -v -x c++ /dev/null')
+    let g:cpp_path_compiler = get(g:, 'cpp_path_compiler', executable('clang') ? 'clang' : 'gcc')
+    let g:cpp_path = ['.'] + s:CPreProcIncludes(g:cpp_path_compiler, '-E -v -x c++ /dev/null')
   endif
   call apathy#Prepend('path', g:cpp_path)
 else
   if !exists('g:c_path')
-    let g:c_path = ['.'] + s:CPreProcIncludes(s:exe . ' -v -x c /dev/null')
+    let g:c_path_compiler = get(g:, 'c_path_compiler', executable('clang') ? 'clang' : 'gcc')
+    let g:c_path = ['.'] + s:CPreProcIncludes(g:c_path_compiler, '-E -v -x c /dev/null')
   endif
   call apathy#Prepend('path', g:c_path)
 endif
 
-unlet! s:exe
 setlocal include&
 setlocal includeexpr&
 setlocal define&

--- a/after/ftplugin/c_apathy.vim
+++ b/after/ftplugin/c_apathy.vim
@@ -15,8 +15,8 @@ endfunction
 
 if &filetype ==# 'cpp' 
   if !exists('g:cpp_path')
-    let g:cpp_path_compiler = get(g:, 'cpp_path_compiler', executable('clang') ? 'clang' : 'gcc')
-    let g:cpp_path = ['.'] + s:CPreProcIncludes(g:cpp_path_compiler, '-E -v -x c++ /dev/null')
+    let g:c_path_compiler = get(g:, 'c_path_compiler', executable('clang') ? 'clang' : 'gcc')
+    let g:cpp_path = ['.'] + s:CPreProcIncludes(g:c_path_compiler, '-E -v -x c++ /dev/null')
   endif
   call apathy#Prepend('path', g:cpp_path)
 else


### PR DESCRIPTION
If `clang` available, vim-apathy uses the `clang` compiler for finding system include paths, and `gcc` as fallback. Put `let g:c_path_compiler = 'gcc'` in your vimrc to always use `gcc` for finding system include directories (for both C and C++).