### PR TITLE
set &define in javascript to look up functions, methods and classes

### DIFF
--- a/after/ftplugin/javascript_apathy.vim
+++ b/after/ftplugin/javascript_apathy.vim
@@ -28,3 +28,36 @@ function! JavascriptNodeFind(target, current) abort
   endif
   return target
 endfunction
+
+" adapted from https://github.com/romainl/ctags-patterns-for-javascript
+let &l:define = '\v' . (empty(&l:define) ? '' : '|')
+
+" classes
+let &l:define .= '^\s*var\s+\ze[A-Z]\i+\s*\=\s*function|' .
+                  \ '^\s*let\s+\ze[A-Z]\i+\s*\=\s*function|' .
+                  \ '^\s*const\s+\ze[A-Z]\i+\s*\=\s*function|' .
+                  \ '^\s*class\s+\ze\i+|'
+
+" methods
+let &l:define .= '^\s*this\.\ze\i+\s*\=.*\{$|' .
+      \ '^\s*\ze\i+\s*[:=]\s*\(*function\s*\(|' .
+      \ '^\s*\ze\i+\s*\=\s.+\=\>|' .
+      \ '^\s*static\s+\ze\i+\s*\(|' .
+      \ '^\s*\ze\i+\(.*\)\s*\{|'
+
+" generator functions
+let &l:define .= '^\s*function\s*\*\s*\(\ze\i+\)|' .
+      \ '^\s*var\s+\ze[a-z]\i+\s*\=\s*function\(\s*\*\)|' .
+      \ '^\s*let\s+\ze[a-z]\i+\s*\=\s*function\(\s*\*\)|' .
+      \ '^\s*const\s+\ze[a-z]\i+\s*\=\s*function\(\s*\*\)|' .
+      \ '^\s*\(\*\s\)\ze\i+\s*.*\s*\{|'
+
+" free-form functions
+let &l:define .= '^\s*function\s*\i+[[:space:](]|' .
+                  \ '^\s*\(function\s*\i+[[:space:](]|' .
+                  \ '^\s*var\s+\ze[a-z]\i+\s*\=\s*function[^\*][^\*]|' .
+                  \ '^\s*let\s+\ze[a-z]\i+\s*\=\s*function[^\*][^\*]|' .
+                  \ '^\s*const\s+\ze[a-z]\i+\s*\=\s*function[^\*][^\*]|' .
+                  \ '^\s*var\s+\ze[a-z]\i+\s*\=\s*\([^\*]|' .
+                  \ '^\s*let\s+\ze[a-z]\i+\s*\=\s*\([^\*]|' .
+                  \ '^\s*const\s+\ze[a-z]\i+\s*\=\s*\([^\*]'


### PR DESCRIPTION
Adapted from https://github.com/romainl/ctags-patterns-for-javascript to Vim's regular expression syntax. Making good use of `\ze` to match labels coming before the syntax markers. This is a follow-up to https://github.com/tpope/vim-apathy/issues/9#issuecomment-473923678