### PR TITLE
Force vim to use our custom includeexpr to get to the correct file

### DIFF
--- a/after/ftplugin/javascript_apathy.vim
+++ b/after/ftplugin/javascript_apathy.vim
@@ -1,11 +1,3 @@
-let b:node_modules = finddir('node_modules', fnamemodify(resolve(apathy#Real(@%)), ':h').';', -1)
-if empty(b:node_modules)
-  unlet b:node_modules
-  finish
-endif
-call map(b:node_modules, 'fnamemodify(v:val, ":p:s?[\\/]$??")')
-
-call apathy#Prepend('path', b:node_modules, apathy#EnvSplit($NODE_PATH))
 call apathy#Prepend('suffixesadd', '.coffee,.ts,.tsx,.js,.mjs,.jsx,.json,.node')
 call apathy#Append('suffixesadd', '/package.json')
 setlocal include=\\%(\\<require\\s*(\\s*\\\|\\<import\\>[^;\"']*\\)[\"']\\zs[^\"']*
@@ -13,16 +5,37 @@ setlocal includeexpr=JavascriptNodeFind(v:fname,@%)
 
 call apathy#Undo()
 
+let b:node_modules = finddir('node_modules', fnamemodify(resolve(apathy#Real(@%)), ':h').';', -1)
+
+if empty(b:node_modules)
+  unlet b:node_modules
+  finish
+endif
+
+call map(b:node_modules, 'fnamemodify(v:val, ":p:s?[\\/]$??")')
+
+call apathy#Prepend('path', b:node_modules, apathy#EnvSplit($NODE_PATH))
+
+if executable('npm')
+  call apathy#Append('path', substitute(system('npm root -g'), '\v\n+$', '', ''))
+endif
+
+let b:modules_path = &path
+
+" Force vim to use our includeexpr so we have a chance to parse the
+" package.json and extract main
+setlocal path=''
+
 function! JavascriptNodeFind(target, current) abort
   let target = substitute(a:target, '^\~[^/]\@=', '', '')
   if target =~# '^\.\.\=/'
     let target = simplify(fnamemodify(resolve(a:current), ':p:h') . '/' . target)
   endif
-  let found = findfile(target)
+  let found = findfile(target, b:modules_path)
   if found =~# '[\/]package\.json$' && target !~# '[\/]package\.json$'
     try
       let package = json_decode(join(readfile(found)))
-      let target .= '/' . substitute(get(package, 'main', 'index'), '\.js$', '', '')
+      let target = fnamemodify(found, ':h') . '/' . substitute(get(package, 'main', 'index'), '\.js$', '', '')
     catch
     endtry
   endif


### PR DESCRIPTION
Also added basic support for globally installed packages when npm is
used.

This is my first foray at modifying a vim plugin after a bit of reading about VimL so I welcome any suggestion for improvement and or criticism. Unsetting the path feels hacky but I don't see an other way to avoid editing directories, having to manually look for the main entry and then gf-ing again on that file.