### PR TITLE
Support typescriptreact, javascriptreact filetypes

### DIFF
--- a/after/ftplugin/javascriptreact_apathy.vim
+++ b/after/ftplugin/javascriptreact_apathy.vim
@@ -1,0 +1,1 @@
+source <sfile>:h/javascript_apathy.vim

--- a/after/ftplugin/typescriptreact_apathy.vim
+++ b/after/ftplugin/typescriptreact_apathy.vim
@@ -1,0 +1,1 @@
+source <sfile>:h/javascript_apathy.vim


### PR DESCRIPTION
Hi, thanks a lot for making this plugin!

I started having a problem after upgrading vim to 8.2 - vim-apathy stopped working for `.tsx` files.

I found that `.tsx` now have their own filetype (and same for `.jsx`).
See vim patch 8.1.1930:
https://github.com/vim/vim/commit/92852cee3fcff1dc6ce12387b234634e73267b22

Would you be willing to accept this change to treat `typescriptreact` and `javascriptreact` filetypes as JavaScript from apathy’s perspective?